### PR TITLE
Fixed method call on pointer type

### DIFF
--- a/evaluable.go
+++ b/evaluable.go
@@ -105,19 +105,20 @@ func variable(path ...Evaluable) Evaluable {
 				}
 			default:
 				vv := reflect.ValueOf(o)
+				vvElem := vv
 
 				// if this is a pointer, resolve it.
 				if vv.Kind() == reflect.Ptr {
-					vv = vv.Elem()
+					vvElem = vv.Elem()
 				}
 
 				//check generic for maps and arrays
 
-				if vv.Kind() != reflect.Struct {
+				if vvElem.Kind() != reflect.Struct {
 					break
 				}
 
-				field := vv.FieldByName(k)
+				field := vvElem.FieldByName(k)
 				if field.IsValid() {
 					v = field.Interface()
 					continue


### PR DESCRIPTION
It's currently impossible to do a method call on a pointer of a struct. Let's assume the following type:
```go
type Example {
}

func (example *Example) Hello() string {
  return "Hi!"
}

func NewExample() *Example {
  return &Example{}
}
```

If we'd use `NewExample().Hello()` in the gval.Evaluate func we would get something like: "parameter .Hello() not found". This is because in the variable func (evaluate.go:86) you resolve the pointer. This is required for finding the type of the element and for walking the fields but for walking the methods you should use the original value, in this case the pointer.

With this pull request this issue is fixed.