### PR TITLE
Adding new type map[interface{}]interface{}

### DIFF
--- a/evaluable.go
+++ b/evaluable.go
@@ -95,6 +95,9 @@ func variable(path ...Evaluable) Evaluable {
 		}
 		for i, k := range keys {
 			switch o := v.(type) {
+			case map[interface{}]interface{}:
+				v = o[k]
+				continue
 			case map[string]interface{}:
 				v = o[k]
 				continue


### PR DESCRIPTION
when Unmarshal'ing Yaml files, maps are type map[interface{}]interface{}