### PR TITLE
zero value argument when function is called by reflect

### DIFF
--- a/evaluable.go
+++ b/evaluable.go
@@ -233,7 +233,11 @@ func (*Parser) callEvaluable(fullname string, fun Evaluable, args ...Evaluable) 
 			if err != nil {
 				return nil, err
 			}
-			a[i] = reflect.ValueOf(arg)
+			if arg == nil {
+				a[i] = reflect.Zero(ff.Type().In(i))
+			} else {
+				a[i] = reflect.ValueOf(arg)
+			}
 		}
 
 		rr := ff.Call(a)

--- a/functions.go
+++ b/functions.go
@@ -62,8 +62,14 @@ func createCallArguments(t reflect.Type, args []interface{}) ([]reflect.Value, e
 		} else if i == numIn-1 {
 			inType = t.In(numIn - 1).Elem()
 		}
-		argVal := reflect.ValueOf(arg)
-		if arg == nil || !argVal.Type().AssignableTo(inType) {
+
+		var argVal reflect.Value
+		if arg == nil {
+			argVal = reflect.Zero(t.In(i))
+		} else {
+			argVal = reflect.ValueOf(arg)
+		}
+		if !argVal.Type().AssignableTo(inType) {
 			return nil, fmt.Errorf("expected type %s for parameter %d but got %T",
 				inType.String(), i, arg)
 		}

--- a/gval_parameterized_test.go
+++ b/gval_parameterized_test.go
@@ -592,6 +592,36 @@ func TestParameterized(t *testing.T) {
 				},
 				want: 1.,
 			},
+			{
+				name:       "nil argument of function in parameter",
+				expression: "fn.isNil(hello.world)",
+				parameter: map[string]interface{}{
+					"hello": map[string]interface{}{
+						"world": nil,
+					},
+					"fn": map[string]interface{}{
+						"isNil": func(arg interface{}) bool {
+							return arg == nil
+						},
+					},
+				},
+				want: true,
+			},
+			{
+				name:       "nil argument of function in language",
+				expression: "isNil(hello.world)",
+				parameter: map[string]interface{}{
+					"hello": map[string]interface{}{
+						"world": nil,
+					},
+				},
+				extension: NewLanguage(
+					Function("isNil", func(arg interface{}) (interface{}, error) {
+						return arg == nil, nil
+					}),
+				),
+				want: true,
+			},
 		},
 		t,
 	)


### PR DESCRIPTION
When calling a function with the nil argument,  following error occurred: 
`failed to execute function 'xxx': reflect: Call using zero Value argument`


The following code has been added to avoid errors when creating argument slice.
```go
if arg == nil {
	a[i] = reflect.Zero(ff.Type().In(i))
} else {
```