### PR TITLE
Adding support for functions which accept context as first parameter.

### DIFF
--- a/evaluable.go
+++ b/evaluable.go
@@ -202,7 +202,7 @@ func (*Parser) callFunc(fun function, args ...Evaluable) Evaluable {
 			}
 			a[i] = ai
 		}
-		return fun(a...)
+		return fun(c, a...)
 	}
 }
 


### PR DESCRIPTION
This allows functions to use the context provided when the
Evaluable is evaluated.