### PR TITLE
Shorthand function to evaluate with context

### DIFF
--- a/gval.go
+++ b/gval.go
@@ -16,11 +16,16 @@ import (
 
 //Evaluate given parameter with given expression in gval full language
 func Evaluate(expression string, parameter interface{}, opts ...Language) (interface{}, error) {
+	return EvaluateWithContext(context.Background(), expression, parameter, opts...)
+}
+
+//Evaluate given parameter with given expression in gval full language using a context
+func EvaluateWithContext(c context.Context, expression string, parameter interface{}, opts ...Language) (interface{}, error) {
 	l := full
 	if len(opts) > 0 {
 		l = NewLanguage(append([]Language{l}, opts...)...)
 	}
-	return l.Evaluate(expression, parameter)
+	return l.EvaluateWithContext(c, expression, parameter)
 }
 
 // Full is the union of Arithmetic, Bitmask, Text, PropositionalLogic, and Json

--- a/language.go
+++ b/language.go
@@ -70,11 +70,16 @@ func (l Language) NewEvaluable(expression string) (Evaluable, error) {
 
 // Evaluate given parameter with given expression
 func (l Language) Evaluate(expression string, parameter interface{}) (interface{}, error) {
+	return l.EvaluateWithContext(context.Background(), expression, parameter)
+}
+
+// Evaluate given parameter with given expression using context
+func (l Language) EvaluateWithContext(c context.Context, expression string, parameter interface{}) (interface{}, error) {
 	eval, err := l.NewEvaluable(expression)
 	if err != nil {
 		return nil, err
 	}
-	v, err := eval(context.Background(), parameter)
+	v, err := eval(c, parameter)
 	if err != nil {
 		return nil, fmt.Errorf("can not evaluate %s: %v", expression, err)
 	}


### PR DESCRIPTION
Adding a method to do `EvaluateWithContext` in addition to `Evaluate` for shorthand access.

@generikvault  - Maybe this is just bloating your project (just delete this PR), but if it don't it would be nice to use this shorthand!

Cheers,
 Mario :)