### PR TITLE
A few code cleanups as suggested by staticcheck

### DIFF
--- a/evaluable.go
+++ b/evaluable.go
@@ -297,7 +297,7 @@ func regEx(a, b Evaluable) (Evaluable, error) {
 			return matched, err
 		}, nil
 	}
-	s, err := b.EvalString(nil, nil)
+	s, err := b.EvalString(context.TODO(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +329,7 @@ func notRegEx(a, b Evaluable) (Evaluable, error) {
 			return !matched, err
 		}, nil
 	}
-	s, err := b.EvalString(nil, nil)
+	s, err := b.EvalString(context.TODO(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/language.go
+++ b/language.go
@@ -254,8 +254,7 @@ func (l *Language) makePrefixKey(key string) interface{} {
 }
 
 func (l *Language) makeInfixKey(key string) string {
-	runes := []rune(key)
-	for _, r := range runes {
+	for _, r := range key {
 		l.operatorSymbols[r] = struct{}{}
 	}
 	return key

--- a/operator.go
+++ b/operator.go
@@ -104,7 +104,6 @@ func (op *infix) initiate(name string) {
 			return f(a, b)
 		}, nil
 	}
-	return
 }
 
 type opFunc func(a, b interface{}) (interface{}, error)

--- a/parse.go
+++ b/parse.go
@@ -120,8 +120,7 @@ func (p *Parser) parseOperator(c context.Context, stack *stageStack, eval Evalua
 			p.Camouflage("operator")
 			return stage{Evaluable: eval}, nil
 		}
-		operator, _ := p.operators[op]
-		switch operator := operator.(type) {
+		switch operator := p.operators[op].(type) {
 		case *infix:
 			return stage{
 				Evaluable:          eval,

--- a/parser.go
+++ b/parser.go
@@ -19,7 +19,7 @@ type Parser struct {
 func newParser(expression string, l Language) *Parser {
 	sc := scanner.Scanner{}
 	sc.Init(strings.NewReader(expression))
-	sc.Error = func(*scanner.Scanner, string) { return }
+	sc.Error = func(*scanner.Scanner, string) {}
 	sc.Filename = expression + "\t"
 	p := &Parser{scanner: sc, Language: l}
 	p.resetScannerProperties()
@@ -81,7 +81,6 @@ func (p *Parser) Camouflage(unit string, expected ...rune) {
 		panic(fmt.Errorf("can only Camouflage() after Scan(): %v", p.camouflage))
 	}
 	p.camouflage = p.Expected(unit, expected...)
-	return
 }
 
 // Peek returns the next Unicode character in the source without advancing

--- a/random_test.go
+++ b/random_test.go
@@ -13,7 +13,6 @@ var (
 	hello  = "hello"
 	empty  struct{}
 	empty2 *string
-	empty3 *int
 
 	values = []interface{}{
 		-1,
@@ -101,13 +100,9 @@ var (
 		"\n",
 		"\000",
 	}
-
-	panics = 0
 )
 
-const (
-	SEED = 1487873697990155515
-)
+const SEED = 1487873697990155515
 
 func BenchmarkRandom(bench *testing.B) {
 	rand.Seed(SEED)


### PR DESCRIPTION
This commits adds in a few suggestions that I got from staticcheck. I also cleaned up a bit further in some cases.
Below are the report from staticcheck:
```
/home/jacob/Downloads/gval/evaluable.go
  (300, 25)  SA1012  do not pass a nil Context, even if a function permits it; pass context.TODO if you are unsure about which Context to use
  (332, 25)  SA1012  do not pass a nil Context, even if a function permits it; pass context.TODO if you are unsure about which Context to use

/home/jacob/Downloads/gval/language.go
  (258, 2)  SA6003  should range over string, not []rune(string)

/home/jacob/Downloads/gval/operator.go
  (107, 2)  S1023  redundant return statement

/home/jacob/Downloads/gval/parse.go
  (123, 3)  S1005  unnecessary assignment to the blank identifier

/home/jacob/Downloads/gval/parser.go
  (22, 46)  S1023  redundant return statement
  (84, 2)   S1023  redundant return statement

/home/jacob/Downloads/gval/random_test.go
  (16, 2)   U1000  var empty3 is unused
  (105, 2)  U1000  var panics is unused
```