### PR TITLE
check reflect for nil pointer type and check nil for interface{} type…

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -448,3 +448,27 @@ func ExampleParser_ParseSublanguage() {
 	// Output:
 	// hello world
 }
+
+func ExampleEvaluate_NullStructField() {
+	user := struct {
+		ProjectID *uint
+	}{}
+	user.ProjectID = nil // its nil
+
+	// alternatively: "ProjectID > 0" will return the same, because nil ptr will use zero value '0'
+	value, err := gval.Evaluate("(ProjectID ?? 0) > 0", user)
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(value)
+
+	value, err = gval.Evaluate("(ProjectID ?? 99) > 0", user)
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(value)
+
+	// Output:
+	// false
+	// true
+}

--- a/gval.go
+++ b/gval.go
@@ -103,9 +103,17 @@ var full = NewLanguage(arithmetic, bitmask, text, propositionalLogic, ljson,
 	InfixOperator("in", inArray),
 
 	InfixShortCircuit("??", func(a interface{}) (interface{}, bool) {
+		if v := reflect.ValueOf(a); v.Kind() == reflect.Ptr && v.IsNil() {
+			return nil, false
+		}
+
 		return a, a != false && a != nil
 	}),
 	InfixOperator("??", func(a, b interface{}) (interface{}, error) {
+		if v := reflect.ValueOf(a); v.Kind() == reflect.Ptr && v.IsNil() {
+			return b, nil
+		}
+
 		if a == false || a == nil {
 			return b, nil
 		}

--- a/operator.go
+++ b/operator.go
@@ -131,6 +131,12 @@ func convertToBool(o interface{}) (bool, bool) {
 		return b, true
 	}
 	v := reflect.ValueOf(o)
+
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		// if nil return default zero value false
+		return false, true
+	}
+
 	for o != nil && v.Kind() == reflect.Ptr {
 		v = v.Elem()
 		o = v.Interface()
@@ -171,6 +177,12 @@ func convertToFloat(o interface{}) (float64, bool) {
 		return i, true
 	}
 	v := reflect.ValueOf(o)
+
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		// if nil return default zero value 0
+		return 0, true
+	}
+
 	for o != nil && v.Kind() == reflect.Ptr {
 		v = v.Elem()
 		o = v.Interface()


### PR DESCRIPTION
- for fallback return zero value if nil pointer found in `convertToBool()` and `convertToFloat()` instead of panic
- check nil `interface{}` for `??` operator using reflection, because interface holding a `nil` value is not `nil`