### PR TITLE
Parser.Const Go1.17 compatibility

### DIFF
--- a/evaluable.go
+++ b/evaluable.go
@@ -75,6 +75,7 @@ func (*Parser) Const(value interface{}) Evaluable {
 	return constant(value)
 }
 
+//go:noinline
 func constant(value interface{}) Evaluable {
 	return func(c context.Context, v interface{}) (interface{}, error) {
 		return value, nil


### PR DESCRIPTION
`Evaluable.IsConst` relies on a `constant` function code pointer. But since Go1.17 functions containing closures can be inlined: https://golang.org/doc/go1.17#compiler
This causes `Evaluable.IsConst` to always return false and tests fails on Go1.17:
```
$ go1.16.7 test ./...                     
ok  	github.com/PaesslerAG/gval	0.023s

$ go1.17.2 test ./... 
--- FAIL: TestEvaluable_IsConst (0.00s)
    --- FAIL: TestEvaluable_IsConst/const (0.00s)
        evaluable_test.go:32: Evaluable.IsConst() = false, want true
--- FAIL: TestParsingFailure (0.00s)
    --- FAIL: TestParsingFailure/Constant_regex_pattern_fail_to_compile (0.00s)
        gval_test.go:29: Evaluate(foo =~ `[abc`) expected error missing closing ] but got error can not evaluate foo =~ `[abc`: unknown parameter foo
    --- FAIL: TestParsingFailure/Constant_unmatch_regex_pattern_fail_to_compile (0.00s)
        gval_test.go:29: Evaluate(foo !~ `[abc`) expected error missing closing ] but got error can not evaluate foo !~ `[abc`: unknown parameter foo
FAIL
FAIL	github.com/PaesslerAG/gval	0.021s
FAIL
```