### PR TITLE
Add DecimalArithmetic language

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -107,6 +107,24 @@ func BenchmarkGval(bench *testing.B) {
 			expression: `foo.Nested.Funk`,
 			parameter:  fooFailureParameters,
 		},
+		{
+			name:       "decimal arithmetic",
+			expression: "(requests_made * requests_succeeded / 100)",
+			extension:  decimalArithmetic,
+			parameter: map[string]interface{}{
+				"requests_made":      99.0,
+				"requests_succeeded": 90.0,
+			},
+		},
+		{
+			name:       "decimal logic",
+			expression: "(requests_made * requests_succeeded / 100) >= 90",
+			extension:  decimalArithmetic,
+			parameter: map[string]interface{}{
+				"requests_made":      99.0,
+				"requests_succeeded": 90.0,
+			},
+		},
 	}
 	for _, benchmark := range benchmarks {
 		eval, err := Full().NewEvaluable(benchmark.expression)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/PaesslerAG/gval
+module github.com/machship-mm/gval
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/PaesslerAG/gval
 
 go 1.15
 
-require github.com/PaesslerAG/jsonpath v0.1.0
+require (
+	github.com/PaesslerAG/jsonpath v0.1.0
+	github.com/shopspring/decimal v1.3.1
+)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/machship-mm/gval
+module github.com/PaesslerAG/gval
 
 go 1.15
 

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/PaesslerAG/jsonpath v0.1.0 h1:gADYeifvlqK3R3i2cR5B4DGgxLXIPb3TRTH1mGi0jPI=
 github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
+github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/gval_parameterized_test.go
+++ b/gval_parameterized_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/shopspring/decimal"
 )
 
 func TestParameterized(t *testing.T) {
@@ -623,6 +625,69 @@ func TestParameterized(t *testing.T) {
 					Flag *uint
 				}{},
 				want: 2.,
+			},
+			{
+				name:       "Decimal math doesn't experience rounding error",
+				expression: "(x * 12.146) - y",
+				extension:  decimalArithmetic,
+				parameter: map[string]interface{}{
+					"x": 12.5,
+					"y": -5,
+				},
+				want:         decimal.NewFromFloat(156.825),
+				equalityFunc: decimalEqualityFunc,
+			},
+			{
+				name:       "Decimal logical operators fractional difference",
+				expression: "((x * 12.146) - y) > 156.824999999",
+				extension:  decimalArithmetic,
+				parameter: map[string]interface{}{
+					"x": 12.5,
+					"y": -5,
+				},
+				want: true,
+			},
+			{
+				name:       "Decimal logical operators whole number difference",
+				expression: "((x * 12.146) - y) > 156",
+				extension:  decimalArithmetic,
+				parameter: map[string]interface{}{
+					"x": 12.5,
+					"y": -5,
+				},
+				want: true,
+			},
+			{
+				name:       "Decimal logical operators exact decimal match against GT",
+				expression: "((x * 12.146) - y) > 156.825",
+				extension:  decimalArithmetic,
+				parameter: map[string]interface{}{
+					"x": 12.5,
+					"y": -5,
+				},
+				want: false,
+			},
+			{
+				name:       "Decimal logical operators exact equality",
+				expression: "((x * 12.146) - y) == 156.825",
+				extension:  decimalArithmetic,
+				parameter: map[string]interface{}{
+					"x": 12.5,
+					"y": -5,
+				},
+				want: true,
+			},
+			{
+				name:       "Decimal mixes with string logic with force fail",
+				expression: `(((x * 12.146) - y) == 156.825) && a == "test" && !b && b`,
+				extension:  decimalArithmetic,
+				parameter: map[string]interface{}{
+					"x": 12.5,
+					"y": -5,
+					"a": "test",
+					"b": false,
+				},
+				want: false,
 			},
 		},
 		t,

--- a/language.go
+++ b/language.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"text/scanner"
 	"unicode"
+
+	"github.com/shopspring/decimal"
 )
 
 // Language is an expression language
@@ -220,6 +222,11 @@ func InfixTextOperator(name string, f func(a, b string) (interface{}, error)) La
 // InfixNumberOperator for two number values.
 func InfixNumberOperator(name string, f func(a, b float64) (interface{}, error)) Language {
 	return newLanguageOperator(name, &infix{number: f})
+}
+
+// InfixDecimalOperator for two decimal values.
+func InfixDecimalOperator(name string, f func(a, b decimal.Decimal) (interface{}, error)) Language {
+	return newLanguageOperator(name, &infix{decimal: f})
 }
 
 // InfixBoolOperator for two bool values.

--- a/parse.go
+++ b/parse.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strconv"
 	"text/scanner"
+
+	"github.com/shopspring/decimal"
 )
 
 //ParseExpression scans an expression into an Evaluable.
@@ -88,6 +90,14 @@ func parseNumber(c context.Context, p *Parser) (Evaluable, error) {
 		return nil, err
 	}
 	return p.Const(n), nil
+}
+
+func parseDecimal(c context.Context, p *Parser) (Evaluable, error) {
+	n, err := strconv.ParseFloat(p.TokenText(), 64)
+	if err != nil {
+		return nil, err
+	}
+	return p.Const(decimal.NewFromFloat(n)), nil
 }
 
 func parseParentheses(c context.Context, p *Parser) (Evaluable, error) {


### PR DESCRIPTION
This pull request will merge in the handling of DecimalArithmetic.

Decimal (base10 numbers) arithmetic is different to floating point (base2 numbers) arithmetic, and in use cases that involve money, it's imperative that the user is given the option to have any arithmetic calculations made using fixed-point decimal numbers rather than floating point. 

`DecimalArithmetic` is added and used strictly as an optional use case (not added to the `full()` language set). It is not used unless one specifies its use. 

Use can be specified by calling the `DecimalArithmetic` language directly and evaluation expressions against that language. `DecimalArithmetic` overrides the default handling for `scanner.Int` and `scanner.Float` to use `parseDecimal` and then all arithmetic is run against the `decimal.Decimal` from the widely used [shopspring/decimal](https://github.com/shopspring/decimal) repository.

Tests and Benchmark Tests have been added.

This pull request fixes #70.