### PR TITLE
Allow nil arguments for function

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -104,7 +104,9 @@ func createCallArguments(ctx context.Context, t reflect.Type, args []interface{}
 			inType = t.In(numIn - 1).Elem()
 		}
 		argVal := reflect.ValueOf(arg)
-		if arg == nil || !argVal.Type().AssignableTo(inType) {
+		if arg == nil {
+			argVal = reflect.ValueOf(reflect.Interface)
+		} else if !argVal.Type().AssignableTo(inType) {
 			return nil, fmt.Errorf("expected type %s for parameter %d but got %T",
 				inType.String(), i, arg)
 		}

--- a/functions_test.go
+++ b/functions_test.go
@@ -130,6 +130,17 @@ func Test_toFunc(t *testing.T) {
 			},
 			wantErr: context.DeadlineExceeded,
 		},
+		{
+			name: "nil arg",
+			function: func(a interface{}) bool {
+				if a != nil {
+					return true
+				}
+				return false
+			},
+			arguments: []interface{}{nil},
+			want:      true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
It allows `nil` as an argument for function, so this chance will use reflect value for the interface when argument is resolved as `nil` instead of throwing an error.

This is necessary for some scenarios where `nil` is expected as an argument but `createCallArguments` throws an error for the `nil` argument hence the underlying referenced function is resulting in an error. eg. `IsNil(i interface {}) bool`.

This will solve this problem but of course, Is there any workaround for this?

Please take a look.