### PR TITLE
fix negation in decimal language

### DIFF
--- a/gval.go
+++ b/gval.go
@@ -205,11 +205,11 @@ var decimalArithmetic = NewLanguage(
 	PrefixExtension(scanner.Int, parseDecimal),
 	PrefixExtension(scanner.Float, parseDecimal),
 	PrefixOperator("-", func(c context.Context, v interface{}) (interface{}, error) {
-		i, ok := convertToFloat(v)
+		i, ok := convertToDecimal(v)
 		if !ok {
 			return nil, fmt.Errorf("unexpected %v(%T) expected number", v, v)
 		}
-		return decimal.NewFromFloat(i).Neg(), nil
+		return i.Neg(), nil
 	}),
 )
 

--- a/gval_parameterized_test.go
+++ b/gval_parameterized_test.go
@@ -12,6 +12,11 @@ import (
 )
 
 func TestParameterized(t *testing.T) {
+	// This is a number that's not exactly representable with a
+	// float64: 2^53 + 1. We also negate it here so that the
+	// negative operator can be more easily tested.
+	nonFloat64Dec, _ := decimal.NewFromString("-18014398509481985")
+
 	testEvaluate(
 		[]evaluationTest{
 			{
@@ -696,6 +701,24 @@ func TestParameterized(t *testing.T) {
 					"b": false,
 				},
 				want: false,
+			},
+			{
+				name:       "Decimal literal negation works",
+				expression: `-x == -1`,
+				extension:  decimalArithmetic,
+				parameter: map[string]interface{}{
+					"x": "1",
+				},
+				want: true,
+			},
+			{
+				name:       "Decimal negation doesn't go through float",
+				expression: `(-x) % 2 == 1`,
+				extension:  decimalArithmetic,
+				parameter: map[string]interface{}{
+					"x": nonFloat64Dec,
+				},
+				want: true,
 			},
 		},
 		t,


### PR DESCRIPTION
Happened to notice this by inspection.

I was even getting some weird errors with just a plain "-1", since I suspect this gets parsed as a negate on the literal "1", but I didn't check too deep into it. But my initial concern was about precision, so I've added a test to that effect as well.