### PR TITLE
Replace %s and %v with %w when wrapping errors

### DIFF
--- a/evaluable.go
+++ b/evaluable.go
@@ -225,7 +225,7 @@ func (*Parser) callEvaluable(fullname string, fun Evaluable, args ...Evaluable) 
 		f, err := fun(c, v)
 
 		if err != nil {
-			return nil, fmt.Errorf("could not call function: %v", err)
+			return nil, fmt.Errorf("could not call function: %w", err)
 		}
 
 		defer func() {

--- a/language.go
+++ b/language.go
@@ -69,7 +69,7 @@ func (l Language) NewEvaluableWithContext(c context.Context, expression string) 
 	}
 	if err != nil {
 		pos := p.scanner.Pos()
-		return nil, fmt.Errorf("parsing error: %s - %d:%d %s", p.scanner.Position, pos.Line, pos.Column, err)
+		return nil, fmt.Errorf("parsing error: %s - %d:%d %w", p.scanner.Position, pos.Line, pos.Column, err)
 	}
 
 	return eval, nil
@@ -88,7 +88,7 @@ func (l Language) EvaluateWithContext(c context.Context, expression string, para
 	}
 	v, err := eval(c, parameter)
 	if err != nil {
-		return nil, fmt.Errorf("can not evaluate %s: %v", expression, err)
+		return nil, fmt.Errorf("can not evaluate %s: %w", expression, err)
 	}
 	return v, nil
 }

--- a/parse.go
+++ b/parse.go
@@ -79,7 +79,7 @@ func (p *Parser) parse(c context.Context) (Evaluable, error) {
 func parseString(c context.Context, p *Parser) (Evaluable, error) {
 	s, err := strconv.Unquote(p.TokenText())
 	if err != nil {
-		return nil, fmt.Errorf("could not parse string: %s", err)
+		return nil, fmt.Errorf("could not parse string: %w", err)
 	}
 	return p.Const(s), nil
 }

--- a/parser.go
+++ b/parser.go
@@ -78,7 +78,7 @@ func (p *Parser) isCamouflaged() bool {
 // Do not call Rewind() on a camouflaged Parser
 func (p *Parser) Camouflage(unit string, expected ...rune) {
 	if p.isCamouflaged() {
-		panic(fmt.Errorf("can only Camouflage() after Scan(): %v", p.camouflage))
+		panic(fmt.Errorf("can only Camouflage() after Scan(): %w", p.camouflage))
 	}
 	p.camouflage = p.Expected(unit, expected...)
 }


### PR DESCRIPTION
WIth this, I can not return errors from custom functions and test for them with `if errors.Is(.....)`.