### PR TITLE
Fix json parsing bug

### DIFF
--- a/gval_parsingFailure_test.go
+++ b/gval_parsingFailure_test.go
@@ -165,6 +165,11 @@ func TestParsingFailure(t *testing.T) {
 				expression: "0 + ,",
 				wantErr:    `unexpected "," while scanning extensions`,
 			},
+			{
+				name:       "Invalid json key:value structure",
+				expression: `{"a"=1}`,
+				wantErr:    `unexpected "=" while scanning object expected ":"`,
+			},
 		},
 		t,
 	)

--- a/parse.go
+++ b/parse.go
@@ -316,9 +316,7 @@ func parseJSONObject(c context.Context, p *Parser) (Evaluable, error) {
 				return nil, err
 			}
 			if p.Scan() != ':' {
-				if err != nil {
-					return nil, p.Expected("object", ':')
-				}
+				return nil, p.Expected("object", ':')
 			}
 			value, err := p.ParseExpression(c)
 			if err != nil {


### PR DESCRIPTION
I ran [govanish](https://github.com/sivukhin/govanish) linter (it still in the WIP phase) against `gval` repo and it found that one error handling branch were eliminated by compiler:
```
2023/12/24 21:05:32 it seems like your code vanished from compiled binary: func=[parseJSONObject], file=[/home/sivukhin/code/gval/parse.go], line=[320], snippet:
	return nil, p.Expected("object", ':')
```

```go
if p.Scan() != ':' {
	if err != nil {
		return nil, p.Expected("object", ':')
	}
}
```
Indeed, errcheck in this case is useless and actually prevent parsing from correct behaviour: rejecting invalid JSON structure.

This PR remove err check and always return error if `p.Scan()` return incorrect symbol.

Also, test `Invalid json key:value structure` for incorrect JSON structure were added (it were red before fix and became green 
after)