### PR TITLE
Add maxParseDepth to limit maximum recursion level, fixes #114

### DIFF
--- a/language.go
+++ b/language.go
@@ -17,6 +17,7 @@ type Language struct {
 	init            extension
 	def             extension
 	selector        func(Evaluables) Evaluable
+	maxParseDepth   *uint64
 }
 
 // NewLanguage returns the union of given Languages as new Language.
@@ -41,6 +42,9 @@ func NewLanguage(bases ...Language) Language {
 		}
 		if base.selector != nil {
 			l.selector = base.selector
+		}
+		if base.maxParseDepth != nil {
+			l.maxParseDepth = base.maxParseDepth
 		}
 	}
 	return l
@@ -144,6 +148,14 @@ func PrefixExtension(r rune, ext func(context.Context, *Parser) (Evaluable, erro
 func Init(ext func(context.Context, *Parser) (Evaluable, error)) Language {
 	l := newLanguage()
 	l.init = ext
+	return l
+}
+
+// MaxParseDepth returns a Language with the maximum parsing recursion depth.
+// A nil maxParseDepth means that parsing has no recursion depth limit.
+func MaxParseDepth(depth uint64) Language {
+	l := newLanguage()
+	l.maxParseDepth = &depth
 	return l
 }
 

--- a/parse.go
+++ b/parse.go
@@ -10,13 +10,6 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-var maxParseDepth uint64 = 1024
-
-// SetMaxParseDepth sets the max depth for the parsing recursion
-func SetMaxParseDepth(depth uint64) {
-	maxParseDepth = depth
-}
-
 // ParseExpression scans an expression into an Evaluable.
 func (p *Parser) ParseExpression(c context.Context) (eval Evaluable, err error) {
 	p.parseDepth++
@@ -24,7 +17,7 @@ func (p *Parser) ParseExpression(c context.Context) (eval Evaluable, err error) 
 		p.parseDepth--
 	}()
 
-	if p.parseDepth > maxParseDepth {
+	if p.maxParseDepth != nil && p.parseDepth > *p.maxParseDepth {
 		return nil, fmt.Errorf("maximum parse depth exceeded")
 	}
 

--- a/parse.go
+++ b/parse.go
@@ -10,8 +10,24 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+var maxParseDepth uint64 = 1024
+
+// SetMaxParseDepth sets the max depth for the parsing recursion
+func SetMaxParseDepth(depth uint64) {
+	maxParseDepth = depth
+}
+
 // ParseExpression scans an expression into an Evaluable.
 func (p *Parser) ParseExpression(c context.Context) (eval Evaluable, err error) {
+	p.parseDepth++
+	defer func() {
+		p.parseDepth--
+	}()
+
+	if p.parseDepth > maxParseDepth {
+		return nil, fmt.Errorf("maximum parse depth exceeded")
+	}
+
 	stack := stageStack{}
 	for {
 		eval, err = p.ParseNextExpression(c)

--- a/parser.go
+++ b/parser.go
@@ -14,6 +14,7 @@ type Parser struct {
 	Language
 	lastScan   rune
 	camouflage error
+	parseDepth  uint64
 }
 
 func newParser(expression string, l Language) *Parser {


### PR DESCRIPTION
This commit introduces a field in Parser struct to keep track of the level of recursion and a limit configurable at package level.